### PR TITLE
Update header with transparency

### DIFF
--- a/project/src/components/Anuncios.tsx
+++ b/project/src/components/Anuncios.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Bell, Calendar, Info, X, ExternalLink } from 'lucide-react';
+import { Bell, Calendar, Info, X } from 'lucide-react';
 
 interface Anuncio {
   id: number;

--- a/project/src/components/Header.tsx
+++ b/project/src/components/Header.tsx
@@ -23,7 +23,7 @@ const Header = () => {
   };
 
   return (
-    <header className="bg-olive-green/80 backdrop-blur-sm shadow-lg sticky top-0 z-50">
+    <header className="bg-olive-green/60 backdrop-blur-sm shadow-lg sticky top-0 z-50">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between items-center py-4">
           <div className="flex items-center space-x-3">
@@ -60,7 +60,7 @@ const Header = () => {
 
         {/* Mobile Navigation */}
         {isMenuOpen && (
-          <div className="lg:hidden bg-olive-green/80 backdrop-blur-sm border-t border-sky-blue">
+          <div className="lg:hidden bg-olive-green/60 backdrop-blur-sm border-t border-sky-blue">
             <nav className="py-4 space-y-2">
               {navItems.map((item) => (
                 <button

--- a/project/src/components/Header.tsx
+++ b/project/src/components/Header.tsx
@@ -23,7 +23,7 @@ const Header = () => {
   };
 
   return (
-    <header className="bg-olive-green shadow-lg sticky top-0 z-50">
+    <header className="bg-olive-green/80 backdrop-blur-sm shadow-lg sticky top-0 z-50">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between items-center py-4">
           <div className="flex items-center space-x-3">
@@ -60,7 +60,7 @@ const Header = () => {
 
         {/* Mobile Navigation */}
         {isMenuOpen && (
-          <div className="lg:hidden bg-olive-green border-t border-sky-blue">
+          <div className="lg:hidden bg-olive-green/80 backdrop-blur-sm border-t border-sky-blue">
             <nav className="py-4 space-y-2">
               {navItems.map((item) => (
                 <button

--- a/project/src/components/Traductor.tsx
+++ b/project/src/components/Traductor.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Languages, ArrowRightLeft, Volume2, Copy } from 'lucide-react';
+import { Languages, ArrowRightLeft, Copy } from 'lucide-react';
 
 const Traductor = () => {
   const [textoEspanol, setTextoEspanol] = useState('');


### PR DESCRIPTION
## Summary
- adjust `Header` component to use semi-transparent background
- fix linter warnings by removing unused icons

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6850ac73e3348332bc074cd7361b76ec